### PR TITLE
Improved Bazaar Integration

### DIFF
--- a/lib/source_control/bazaar.rb
+++ b/lib/source_control/bazaar.rb
@@ -25,7 +25,7 @@ module SourceControl
 
     def latest_revision
       bzr('pull')
-      bzr_output = bzr('log', ['-v', '-r', '-1'])
+      bzr_output = bzr('log', ['-v', '-r', '-1', '--xml'])
       Bazaar::LogParser.new.parse(bzr_output).first
     end
 
@@ -39,7 +39,7 @@ module SourceControl
       elsif bzr_local > bzr_remote
         raise "Local repository is bigger that should be impossible"
       else
-        bzr_output = bzr('missing', ['-v'], :exitstatus => 1)
+        bzr_output = bzr('xmlmissing', ['-v'])
         _new_revisions = Bazaar::LogParser.new.parse(bzr_output)
         reasons << _new_revisions
         return false

--- a/lib/source_control/bazaar/log_parser.rb
+++ b/lib/source_control/bazaar/log_parser.rb
@@ -1,60 +1,67 @@
 require 'date'
+require 'rexml/document'
 
 module SourceControl
   class Bazaar
     class LogParser
 
-      def parse(message)
-
+      def parse(source)
         revisions = []
 
-        entries = split_log(message)
+        xml = REXML::Document.new(source.join(""))
 
-        entries.each do |entry|
-          rev_number = parse_for_rev_number(entry)
-          name = parse_for_name(entry)
-          date = parse_for_date(entry)
-          message, files = parse_for_message_and_files(entry)
-          change_set_entries = []
-          files.each do |file_name|
-            change_set_entries << ChangesetEntry.new("", file_name)
-          end
-          revisions << Revision.new(rev_number, name, date, message, change_set_entries)
+        xml.elements.each("//log") do |log|
+          rev_number = parse_for_rev_number(log)
+          name = parse_for_name(log)
+          date = parse_for_date(log)
+          message = parse_for_message(log)
+          changesets = parse_for_changesets(log)
+          revisions << Revision.new(rev_number, name, date, message, changesets)
         end
 
         revisions
       end
 
-      def parse_for_name(message)
-        name_match = (message.match(/^committer:\s+(.*)\</) ||
-                     message.match(/^committer:\s+(.*)$/))
-        name_match[1].strip
+      def parse_for_rev_number(log)
+        log.elements.to_a("./revno").first.text rescue nil
       end
 
-      def parse_for_date(message)
-        date_string = message.match(/^timestamp:\s+(.*)/)[1].strip
-        DateTime.parse(date_string)
+      def parse_for_name(log)
+        log.elements.to_a("./committer").first.text rescue nil
       end
 
-      def parse_for_message_and_files(message)
-        message, files_text = message.match(/^message:.(.*)^(modified|added|renamed|removed):(.*)/m)[1..2]
-        files = files_text.split(/\s+/)
-        %w{modified: added: renamed: removed:}.each do |header|
-          files.delete(header)
+      def parse_for_date(log)
+        Time.parse(log.elements.to_a("./timestamp").first.text) rescue nil
+      end
+
+      def parse_for_message(log)
+        log.elements.to_a("./message").first.text rescue nil
+      end
+
+      CHANGE_TYPE_MAP = [
+        ["modified",     "M"],
+        ["renamed",      "R"],
+        ["kind-changed", "C"],
+        ["removed",      "D"],
+        ["added",        "A"],
+      ]
+      def parse_for_changesets(log)
+        changesets = []
+        log.elements.each("./affected-files") do |affected_files|
+          CHANGE_TYPE_MAP.each do |element, abbr|
+            type = affected_files.elements.to_a("./#{element}").first
+            next unless type
+            type.elements.each do |item|
+              text = if element == "renamed"
+                "%s => %s" % [item.text, item.attributes["oldpath"]]
+              else
+                item.text
+              end
+              changesets << ChangesetEntry.new(abbr, text)
+            end
+          end
         end
-        [message, files]
-      end
-
-      def parse_for_rev_number(message)
-        message.match(/^revno:\s+(\d+)/)[1]
-      end
-
-      def split_log(message)
-        message = message.join("\n") if message.is_a? Array
-        if message.match(/Branches are up to date/)
-          return []
-        end
-        message.split(/^\s+$/).delete_if {|t| t =~ /^\s+$/ }.map(&:strip)
+        changesets
       end
 
     end

--- a/lib/source_control/bazaar/revision.rb
+++ b/lib/source_control/bazaar/revision.rb
@@ -1,8 +1,7 @@
 module SourceControl
   class Bazaar
 
-  # FIXME: Mercurial revision is almost same as Subversion revision; and Git is not much different. Remove redundancy.
-  class Revision < AbstractRevision
+    class Revision < AbstractRevision
 
       attr_reader :number, :author, :time, :message, :changeset
 
@@ -12,11 +11,13 @@ module SourceControl
       end
 
       def to_s
-        <<-EOL
-Revision #{number} committed by #{author} on #{time.strftime('%Y-%m-%d %H:%M:%S') if time}
-#{message}
-#{changeset ? changeset.collect { |entry| entry.to_s }.join("\n") : nil}
-        EOL
+        output = "Revision #{number}"
+        output << " committed by #{author}" if author
+        output << " on #{time.strftime('%Y-%m-%d %H:%M:%S')}" if time
+        output << "\n\n#{message}" if message
+        output << "\n\n#{changeset.map(&:to_s).join("\n")}" if changeset
+        output << "\n"
+        output
       end
 
       def <=>(other)
@@ -24,7 +25,9 @@ Revision #{number} committed by #{author} on #{time.strftime('%Y-%m-%d %H:%M:%S'
       end
 
       def ==(other)
-        @number == other.number
+        [:class, :number, :author, :time, :message, :changeset].all? do |p|
+          other.send(p) == self.send(p)
+        end
       end
 
       def to_i

--- a/test/unit/source_control/bazaar/log_parser_test.rb
+++ b/test/unit/source_control/bazaar/log_parser_test.rb
@@ -2,133 +2,45 @@ require File.dirname(__FILE__) + '/../../../test_helper'
 require "date"
 
 module SourceControl
-  class Mercurial::LogParserTest < Test::Unit::TestCase
+  class Bazaar::LogParserTest < Test::Unit::TestCase
 
     @@example_log_output_single = <<END
-changeset:   5:c3f57b2b476c
-tag:         tip
-user:        Marcus Ahnve <marcus@re-mind.se>
-date:        Mon Apr 02 16:14:59 2007 +0200
-files:       app/models/mercurial.rb test/unit/mercurial_test.rb
-description:
-moved mercurial back to plugin
+<?xml version="1.0" encoding="UTF-8"?><logs><log><revno>4</revno><committer>Glen Mailer &lt;glen@epigenesys.co.uk&gt;</committer><branch-nick>bzr-epidirs</branch-nick><timestamp>Tue 2010-07-20 16:09:02 +0100</timestamp><message><![CDATA[used full hostname instead of genesys3]]></message><affected-files><modified><file>__init__.py</file></modified></affected-files></log></logs>
 END
 
     @@example_log_output_double = <<END
-changeset:   4:865db6698186
-user:        Marcus Ahnve <marcus@re-mind.se>
-date:        Mon Apr 02 15:42:14 2007 +0200
-files:       app/models/mercurial.rb app/models/project.rb
-description:
-moved mercurial to model
-
-
-changeset:   3:e3f2e642cb26
-user:        Marcus Ahnve <marcus@re-mind.se>
-date:        Sun Apr 01 17:22:59 2007 +0200
-files:       vcs.txt
-description:
-mailing list instruction
+<?xml version="1.0" encoding="UTF-8"?><logs><log><revno>4</revno><committer>Glen Mailer &lt;glen@epigenesys.co.uk&gt;</committer><branch-nick>bzr-epidirs</branch-nick><timestamp>Tue 2010-07-20 16:09:02 +0100</timestamp><message><![CDATA[used full hostname instead of genesys3]]></message><affected-files><modified><file>__init__.py</file></modified></affected-files></log><log><revno>3</revno><committer>Glen Mailer &lt;glen@epigenesys.co.uk&gt;</committer><branch-nick>bzr-epidirs</branch-nick><timestamp>Tue 2010-07-20 11:33:08 +0100</timestamp><message><![CDATA[new epigenesys paths]]></message><affected-files><modified><file>__init__.py</file></modified></affected-files></log></logs>
 END
 
     def setup
-      @parser = Mercurial::LogParser.new
+      @parser = Bazaar::LogParser.new
     end
 
-    def test_should_parse_single_changeset
+    def test_should_parse_double_changeset
       expected = [
-          Mercurial::Revision.new('865db',
-             "Marcus Ahnve",
-             DateTime.parse("Mon Apr 02 15:42:14 2007 +0200"),
-             "moved mercurial to model",
-             [ChangesetEntry.new("", "app/models/mercurial.rb"),
-              ChangesetEntry.new("", "app/models/project.rb")]),
-          Mercurial::Revision.new('e3f2e',
-              'Marcus Ahnve',
-              'Sun Apr 01 17:22:59 2007 +0200',
-              'mailing list instruction',
-              [ChangesetEntry.new("", "vcs.txt")])]
+          Bazaar::Revision.new('4',
+             "Glen Mailer <glen@epigenesys.co.uk>",
+             Time.parse("Tue 2010-07-20 16:09:02 +0100"),
+             "used full hostname instead of genesys3",
+             [ChangesetEntry.new("M", "__init__.py")]),
+          Bazaar::Revision.new('3',
+             "Glen Mailer <glen@epigenesys.co.uk>",
+             Time.parse("Tue 2010-07-20 11:33:08 +0100"),
+             "new epigenesys paths",
+             [ChangesetEntry.new("M", "__init__.py")])]
 
       assert_equal expected, @parser.parse(@@example_log_output_double.split("\n"))
     end
 
     def test_should_parse_single_changeset
-      expected = [Mercurial::Revision.new('c3f57',
-                     "Marcus Ahnve",
-                     DateTime.parse("Mon Apr 02 16:14:59 2007 +0200"),
-                     "moved mercurial back to plugin",
-                     [ChangesetEntry.new("", "app/models/mercurial.rb"),
-                     ChangesetEntry.new("", "test/unit/mercurial_test.rb")])]
+      expected = [Bazaar::Revision.new('4',
+             "Glen Mailer <glen@epigenesys.co.uk>",
+             Time.parse("Tue 2010-07-20 16:09:02 +0100"),
+             "used full hostname instead of genesys3",
+             [ChangesetEntry.new("M", "__init__.py")])]
       assert_equal expected, @parser.parse(@@example_log_output_single.split("\n"))
-    end
-
-    def test_should_parse_a_merge_changeset_with_no_files
-      merge_changeset = <<END
-changeset:   173:6cb3d52e03c6
-tag:         tip
-parent:      171:c2a67e37d51f
-parent:      172:9be005a8f694
-user:        Alex Verkhovsky <alexey.verkhovsky@gmail.com>
-date:        Fri May 09 11:03:54 2008 -0600
-description:
-Fixing config/database.yml to not use the same database name for all databases
-END
-      expected = [Mercurial::Revision.new('6cb3d',
-             "Alex Verkhovsky",
-             DateTime.parse("Fri May 09 11:03:54 2008 -0600"),
-             "Fixing config/database.yml to not use the same database name for all databases",
-             [])]
-      assert_equal expected, @parser.parse(merge_changeset.split("\n"))
-    end
-
-    def test_parse_name
-      assert_equal("Marcus Ahnve", @parser.parse_for_name(@@example_log_output_single))
-    end
-
-    def test_parse_name_when_name_is_not_set
-      input = "user:        joepoon@joe-poons-computer.local"
-      assert_equal "joepoon@joe-poons-computer.local", @parser.parse_for_name(input)
-    end
-
-    def test_parse_date
-      assert_equal(DateTime.parse("Mon Apr 02 16:14:59 2007 +0200"), @parser.parse_for_date(@@example_log_output_single))
-    end
-
-    def test_message
-      assert_equal("moved mercurial back to plugin", @parser.parse_for_message(@@example_log_output_single))
-    end
-
-    def test_parse_rev_number
-      assert_equal('c3f57', @parser.parse_for_rev_number(@@example_log_output_single))
-    end
-
-    def test_parse_files
-      expected = ["app/models/mercurial.rb","test/unit/mercurial_test.rb"]
-      assert_equal(expected, @parser.parse_for_files(@@example_log_output_single))
-    end
-
-    def test_split_multiple_log_entries
-            entry1 =<<END
-changeset:   4:865db6698186
-user:        Marcus Ahnve <marcus@re-mind.se>
-date:        Mon Apr 02 15:42:14 2007 +0200
-files:       app/models/mercurial.rb app/models/project.rb
-description:
-moved mercurial to model
-END
-            entry2 =<<END
-changeset:   3:e3f2e642cb26
-user:        Marcus Ahnve <marcus@re-mind.se>
-date:        Sun Apr 01 17:22:59 2007 +0200
-files:       vcs.txt
-description:
-mailing list instruction
-END
-            expected=[entry1.strip!,entry2.strip!]
-            assert_equal(expected, @parser.split_log(@@example_log_output_double))
     end
 
   end
 
 end
-

--- a/test/unit/source_control/bazaar/revision_test.rb
+++ b/test/unit/source_control/bazaar/revision_test.rb
@@ -1,0 +1,48 @@
+require File.dirname(__FILE__) + '/../../../test_helper'
+
+module SourceControl
+  class Bazaar::RevisionTest < Test::Unit::TestCase
+    def test_equality_operator
+      r1 = Bazaar::Revision.new('10')
+
+      assert r1 == r1
+      assert r1 == Bazaar::Revision.new('10')
+      assert_false r1 == :foo
+      assert_false r1 == Bazaar::Revision.new('20')
+
+      not_a_git_revision = Object.new
+      not_a_git_revision.stubs(:number).returns(r1.number)
+      assert_false r1 == not_a_git_revision
+    end
+
+    def test_should_have_sensible_to_s
+      assert_equal("Revision 10 committed by jeremy\n",
+                   Bazaar::Revision.new('10', "jeremy").to_s)
+      assert_equal("Revision 10 committed by jeremy on 2000-01-02 03:04:00\n",
+                   Bazaar::Revision.new("10", "jeremy", Time.parse("2000-01-02 03:04:00")).to_s)
+    end
+
+    def test_should_convert_to_full_diff_message
+      expected_message = %{Revision 10 committed by Scott Tamosunas on 2000-01-02 03:04:00
+
+fixed iphone cruise Rakefile
+and another line
+
+  M iphone/Rakefile
+  M iphone/ibob/ibob.xcodeproj/pivotal.pbxuser
+  M iphone/ibob/ibob.xcodeproj/project.pbxproj
+}
+
+      revision = Bazaar::Revision.new("10",
+                                      "Scott Tamosunas",
+                                      Time.parse("2000-01-02 03:04"),
+                                      "fixed iphone cruise Rakefile\nand another line",
+                                      [ChangesetEntry.new("M", "iphone/Rakefile"),
+                                       ChangesetEntry.new("M", "iphone/ibob/ibob.xcodeproj/pivotal.pbxuser"),
+                                       ChangesetEntry.new("M", "iphone/ibob/ibob.xcodeproj/project.pbxproj")])
+
+      assert_equal(expected_message, revision.to_s)
+    end
+
+  end
+end

--- a/test/unit/source_control/bazaar_test.rb
+++ b/test/unit/source_control/bazaar_test.rb
@@ -24,7 +24,7 @@ module SourceControl
         Bazaar::LogParser.expects(:new).returns(parser)
 
         @bazaar.expects(:bzr).with("pull")
-        @bazaar.expects(:bzr).with("log", ['-v', '-r', '-1']).returns("log_result")
+        @bazaar.expects(:bzr).with("log", ['-v', '-r', '-1', '--xml']).returns("log_result")
         assert_equal("foo", @bazaar.latest_revision)
       end
     end


### PR DESCRIPTION
This patch fixes some dodgy testcases in the existing bazaar implementation, and re-works the bazaar log parsing (which didn't record file changes).

Requires the bzr plugin bzr-xmloutput to produce the xml log output which is parsed using REXML.
