### PR TITLE
Changes made by a first time cruisecontrol.rb user.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,14 @@
 *~
 coverage
 __sandbox
+
 public/stylesheets/site.css
-public/documentation
+public/documentation*
+public/builds
+
 log/*
 tmp/**/*
 cruisecontrol.iws
-public/builds
 *.iws
 *.ipr
 *.iml

--- a/app/views/build_mailer/build_report.html.erb
+++ b/app/views/build_mailer/build_report.html.erb
@@ -15,7 +15,7 @@ See <%= "#{@build.url}" %> for details.
 <% else -%>
 <%= @message %>
 
-  Note: if you set Configuration.dashboard_url in config/site_config.rb, you'd see a link to the build page here.
+  Note: if you set Configuration.dashboard_url in site_config.rb, you'd see a link to the build page here.
 
 CHANGES
 -------

--- a/config/cruise_config.rb.example
+++ b/config/cruise_config.rb.example
@@ -16,13 +16,15 @@ Project.configure do |project|
   # in version control, it should be '../build_my_app.sh' instead
   # project.build_command = 'build_my_app.sh'
 
-  # Ping Subversion for new revisions every 5 minutes (default: 30 seconds)
-  # project.scheduler.polling_interval = 5.minutes
+  # Set the frequency to poll the repository, to check if there are source control changes
+  # project.scheduler.polling_interval = 1.hour
 
-  # Force the project always build once every day and always build whether there are source control changes or not
-  # project.scheduler.polling_interval = 1.day
-  # project.scheduler.always_build = true
+  # Whether to always build at each polling
+  # project.scheduler.always_build = true # to build no matter whether there are source control changes or not
+  # project.scheduler.always_build = false # to build only when there are source control changes
+   
+  # Set a regular build interval. A build will always be started at each interval,
+  # no matter whether there are source control changes or not; no matter what is the project.scheduler.always_build setting.
+  # project.triggered_by ScheduledBuildTrigger.new(project, :build_interval => 1.day, :start_time => 2.minutes.from_now)
 
-  # Force the project to check for source control changes every given time interval, but NOT build if there are no changes
-  # project.triggered_by ScheduledBuildTrigger.new(project, :build_interval => 5.minutes, :start_time => 2.minutes.from_now)
 end

--- a/config/site_config.rb_example
+++ b/config/site_config.rb_example
@@ -1,7 +1,9 @@
-# site_config.rb contains examples of various configuration options for the local installation
-# of CruiseControl.rb.
+# site_config.rb should contain configuration options for the whole local installation of CruiseControl.rb.
+# It should be located at DATA_ROOT/site_config.rb, ie, ~/.cruise/site_config.rb
 
 # YOU MUST RESTART YOUR CRUISE CONTROL SERVER FOR ANY CHANGES MADE HERE TO TAKE EFFECT!!!
+
+# Repository and project specific configuration is defined at various cruise_config.rb
 
 # EMAIL NOTIFICATION
 # ------------------

--- a/lib/builder_plugins/email_notifier.rb
+++ b/lib/builder_plugins/email_notifier.rb
@@ -10,6 +10,8 @@
 #   project.email_notifier.emails = ['john@doe.com', 'jane@doe.com']
 #   ...
 # end</code></pre>
+# Please note, this setting can be put into project specific cruise_config.rb, usually at ~/.cruise/projects/YourProject/cruise_config.rb
+# Or be put into repository specific cruise_config.rb, ie, YourRepository/cruise_config.rb
 
 # You can also specify who to send the email from, either for the entire site by setting Configuration.email_from
 # in <em>[cruise&nbsp;data]</em>//site_config.rb, or on a per project basis, by placing the following line in cruise_config.rb:

--- a/lib/builder_plugins/email_notifier.rb
+++ b/lib/builder_plugins/email_notifier.rb
@@ -1,18 +1,18 @@
 # CruiseControl.rb can send email notices whenever build is broken or fixed. To make it happen, you need to tell it how
 # to send email, and who to send it to. Do the following:
 # 
-# 1. Configure SMTP server connection. Open <em>[cruise&nbsp;data]</em>/config/site_config.rb,
+# 1. Configure SMTP server connection. Open <em>[cruise&nbsp;data]</em>/site_config.rb,
 #    read the comments in it and edit according to your situation.
-# 
-# 2. Tell the builder, whom do you want to receive build notices:
+
+# 2. Tell the builder, whom do you want to receive build notices.
 # <pre><code>Project.configure do |project|
 #   ...
 #   project.email_notifier.emails = ['john@doe.com', 'jane@doe.com']
 #   ...
 # end</code></pre>
-#
+
 # You can also specify who to send the email from, either for the entire site by setting Configuration.email_from
-# in <em>[cruise&nbsp;data]</em>/config/site_config.rb, or on a per project basis, by placing the following line in cruise_config.rb:
+# in <em>[cruise&nbsp;data]</em>//site_config.rb, or on a per project basis, by placing the following line in cruise_config.rb:
 # <pre><code>Project.configure do |project|
 #   ...
 #   project.email_notifier.from = "cruisecontrol@doe.com"
@@ -20,7 +20,7 @@
 # end</code></pre>
 #
 # The emails from CruiseControl.rb can have a lot of details about the build, or just a link to the build page in the dashboard.
-# Usually, you will want the latter. Set the dashboard URL in the <em>[cruise&nbsp;data]</em>/config/site_config.rb as follows:
+# Usually, you will want the latter. Set the dashboard URL in the <em>[cruise&nbsp;data]</em>/site_config.rb as follows:
 #
 # <pre><code>Configuration.dashboard_url = 'http://your.host.name.com:3333'</pre></code>
 class EmailNotifier < BuilderPlugin

--- a/lib/smtp_tls.rb
+++ b/lib/smtp_tls.rb
@@ -6,15 +6,13 @@ Net::SMTP.class_eval do
     raise IOError, 'SMTP session already started' if @started
 
     if user or secret
-      arity = instance_method(:check_auth_args).arity
-      
-      if arity == 2
+      if RUBY_VERSION < "1.8.7"
+        #Ruby 1.8.6 and below -- check_auth_args takes three args
+        check_auth_args user, secret, authtype
+      else
         #Ruby 1.8.7 and above -- check_auth_args takes two args, check_auth_method is separate
         check_auth_method(authtype || DEFAULT_AUTH_TYPE)
         check_auth_args user, secret
-      else
-        #Ruby 1.8.6 and below -- check_auth_args takes three args
-        check_auth_args user, secret, authtype
       end
     end
 


### PR DESCRIPTION
As a newbie of CC, I was puzzled by some conflicting or confusing comments and examples related to:
the location of config files
project.scheduler.polling_interval, project.scheduler.always_build, project.triggered_by ScheduledBuildTrigger

As a result of my struggle of quite a few hours in trying different testing scenarios, I checked in 3 commits to fix the confusion. These changes may not seem to be indispensable to a veteran user, but they will definitely save new users like myself from unpleasant troubles.

The commit related to .gitignore is obvious.

The commit of fixing sending email in Ruby 1.9.2 coincidently landed on correcting errors in two previous commits. A little bit strange that they were not spotted on the first place by two committers. But as Eric S. Raymond said, given enough eyeballs, all bugs are shallow.

As a side benefit, I approved that CC now runs under Ruby 1.9.2. At the time when I was comparing candidates of continuous integration solutions, I was misled by the statement in CC's web site:
Ruby 1.8.6. (Note: at the time of this writing CruiseControl.rb does not work with Ruby 1.8.7 or 1.9).
http://cruisecontrolrb.thoughtworks.com/documentation/getting_started

As a result of this statement, I played with another candidate for a while before returned to give CC a try. So please change that obsolete statement ASAP ;-)

Thanks for creating this good tool. But there are still more features we want, as always ;-)
