### PR TITLE
Work with new version of rubygems

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -12,6 +12,17 @@ RAILS_GEM_VERSION = '2.3.2' unless defined? RAILS_GEM_VERSION
 require File.join(File.dirname(__FILE__), 'boot')
 ABSOLUTE_RAILS_ROOT = File.expand_path(RAILS_ROOT) unless defined? ABSOLUTE_RAILS_ROOT
 
+unless Gem::VERSION < "1.3.6"
+  module Rails
+    class GemDependency
+      def requirement
+        r = super
+        (r == Gem::Requirement.default) ? nil : r
+      end
+    end
+  end
+end
+
 Rails::Initializer.run do |config|
   # Settings in config/environments/* take precedence over those specified here
   config.gem "xml-simple", :lib => "xmlsimple"


### PR DESCRIPTION
This change allows ccrb to run on systems with the new version of gems, which isn't compatible with older versions of Rails. See http://www.sarahmei.com/blog/2011/02/26/cruisecontrol-rb-and-rubygems-1-5-2/ for references.
