### PR TITLE
Fixed uninitialized constant SourceControl::Subversion::LogParser::XmlSimple

### DIFF
--- a/lib/source_control/subversion/log_parser.rb
+++ b/lib/source_control/subversion/log_parser.rb
@@ -1,3 +1,5 @@
+require "xmlsimple"
+
 module SourceControl
   class Subversion
 
@@ -20,7 +22,7 @@ module SourceControl
         Revision.new(hash['revision'].to_i, hash['author'], date, message, changesets)
       end
     end
-    
+
   end
 end
 


### PR DESCRIPTION
https://cruisecontrolrb.lighthouseapp.com/projects/9150/tickets/284-uninitialized-constant-sourcecontrolsubversionlogparserxmlsimple
