### PR TITLE
LH Ticket #275

### DIFF
--- a/lib/source_control/git/log_parser.rb
+++ b/lib/source_control/git/log_parser.rb
@@ -5,7 +5,7 @@ module SourceControl
         @log = log
         revisions = []
         revision = nil
-        
+
         log.each do |line|
           next if line.blank?
           line.chomp!
@@ -13,21 +13,22 @@ module SourceControl
           when /^commit /
             revisions << revision = Revision.new
             revision.number = line.split[1]
-            
+
           when /^author /
             revision.author, revision.time = read_author_and_time(line)
-            
+
           when /^    /
             (revision.message ||= []) << line.strip
-            
+
           when /^ /
             (revision.changeset ||= []) << line.strip
-            
+
           when /^tree /
           when /^parent /
           when /^committer /
+          when /^encoding /
             # don't care
-            
+
           else
             raise "don't know how to parse #{line}"
           end

--- a/test/unit/source_control/git/log_parser_test.rb
+++ b/test/unit/source_control/git/log_parser_test.rb
@@ -41,6 +41,17 @@ committer Scott Tamosunas and Brian Jenkins <bob-development@googlegroups.com> 1
  6 files changed, 273 insertions(+), 1875 deletions(-)
 EOF
 
+ENCODING_SPECIFIED_LOG_ENTRY = <<EOF
+commit e51d66aa4f708fff1c87eb9afc9c48eaa8d5ffce
+tree 913027773a63829c82eeb8b626949436b216c857
+parent bb52b2f82fea03b7531496c77db01f9348edbbdb
+author Alexey Verkhovsky <alexey.verkhovsky@gmail.com> 1209921867 -0600
+committer Alexey Verkhovsky <alexey.verkhovsky@gmail.com> 1209921867 -0600
+encoding ISO-8859-1
+
+    a comment
+EOF
+
     def test_parse_should_work
       expected_revision = Git::Revision.new(
                               :number => 'e51d66aa4f708fff1c87eb9afc9c48eaa8d5ffce',
@@ -53,11 +64,11 @@ EOF
       assert_equal expected_revision.author, revisions.first.author
       assert_equal expected_revision.time, revisions.first.time
     end
-    
+
     def test_should_split_into_separate_revisions
       revisions = Git::LogParser.new.parse(BIGGER_LOG_ENTRY.split("\n"))
       assert_equal 2, revisions.size
-      
+
       revision = revisions[1]
       assert_equal "5c881c8da857dee2735349c5a36f1f525a347652", revision.number
       assert_equal "renamed \"Unit Test\" target to \"UnitTest\" for developer sanity.\nfixed iphone cruise Rakefile",
@@ -76,5 +87,8 @@ EOF
       assert_equal Time.at(1209921867), time
     end
 
+    def test_parse_line_should_regonize_and_discard_encoding
+      Git::LogParser.new.parse ENCODING_SPECIFIED_LOG_ENTRY.split "\n"
+    end
   end
 end


### PR DESCRIPTION
Fixes LH Ticket #275. Add the ability for git's log parser to handle
encoding as part of the commit object. This brings CCrb with complete
compliance of git master's object format.

https://cruisecontrolrb.lighthouseapp.com/projects/9150/tickets/275-git-log-parser-cannot-parse-iso-8859-1
https://github.com/git/git/blob/master/commit.c#L867
