### PR TITLE
Default to git source control system.

### DIFF
--- a/lib/source_control.rb
+++ b/lib/source_control.rb
@@ -1,6 +1,6 @@
 module SourceControl
 
-  DEFAULT_SCM = "subversion"
+  DEFAULT_SCM = "git"
 
   class << self
 
@@ -26,11 +26,11 @@ module SourceControl
 
     def simple_detect(url)
       case url
-      when /^git:/ then "git"
       when /^svn:/, /^svn\+ssh:/ then "subversion"
       when /^bzr:/, /^bzr\+ssh:/ then "bazaar"
-      else "subversion"
-      end        
+      when /^svn/, /^subversion/, /^svn\+ssh:/ then "subversion"
+      else "git"
+      end
     end
 
     def detect(path)

--- a/script/add_project
+++ b/script/add_project
@@ -15,17 +15,17 @@ if ARGV.first and ARGV.first !~ /^-/
 end
 
 ARGV.options do |opts|
-  opts.banner = "usage: add [project-name] -r [repository] -s [svn|git|hg|bzr]"
+  opts.banner = "usage: add [project-name] -r [repository] -s [git|svn|hg|bzr]"
 
   opts.separator ""
 
   opts.on("-r", "--repository repository", String,
-          "Location of the source control repository for the project (eg. svn://rubyforge.org/var/svn/cruisecontrolrb)") do |v|
+          "Location of the source control repository for the project (e.g. git@github.com:thoughtworks/cruisecontrol.rb.git)") do |v|
     scm_options[:repository] = v
   end
 
   opts.on("-s", "--source-control source_control", String,
-          "Specify the source control manager to use (default: subversion)") do |v|
+          "Specify the source control manager to use (default: git)") do |v|
     scm_options[:source_control] = v
   end
   opts.on("-b", "--branch branch", String, "Specify a source control branch to use (Git, Mercurial)") { |v| scm_options[:branch] = v }

--- a/test/unit/source_control_test.rb
+++ b/test/unit/source_control_test.rb
@@ -11,9 +11,9 @@ class SourceControlTest < Test::Unit::TestCase
     end
   end 
 
-  def test_create_should_default_to_subversion
+  def test_create_should_default_to_git
     in_sandbox do
-      SourceControl::Subversion.expects(:new).with(:repository => "http://my_repo").returns(:foo)
+      SourceControl::Git.expects(:new).with(:repository => "http://my_repo").returns(:foo)
       assert_equal :foo, SourceControl.create(:repository => "http://my_repo")
     end
   end


### PR DESCRIPTION
This one warrants discussion, obviously.

I would wager that for most Ruby and Rails projects that Git is now the primary source control system. In light of that (and, frankly, because I think Git is a better SCM that SVN), I think it may be a good idea to default to git instead of svn.
