### PR TITLE
Kill builder

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -56,7 +56,21 @@ class ProjectsController < ApplicationController
       end
     end
   end
-  
+
+  def kill_build
+    @project = Project.find(params[:id])
+    @project.kill_build rescue nil
+    respond_to do |format|
+      format.html do
+        if request.xhr?
+          render_projects_partial(Project.all)
+        else
+          redirect_to :action => 'index'
+        end
+      end
+    end
+  end
+
   def code
     if Configuration.disable_code_browsing
       render :text => "Code browsing disabled" and return

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -360,7 +360,11 @@ class Project
       source_control.update(revision)
     end
   end
-  
+
+  def kill_build
+    Platform.kill_child_process(self.name)
+  end
+
   def build(revision = source_control.latest_revision, reasons = [])
     if Configuration.serialize_builds
       BuildSerializer.serialize(self) { build_without_serialization(revision, reasons) }

--- a/app/views/builds/_build_buttons.html.erb
+++ b/app/views/builds/_build_buttons.html.erb
@@ -1,15 +1,21 @@
 <div class="buttons">
   <%= form_tag(build_project_path(:id => project), :class => "build_project") do %>
-  
-    <% if project.builder_down? %>    
+
+    <% if project.builder_down? %>
       <button type="submit" name="build_now" class="build_button">Start Builder</button>
     <% elsif project.can_build_now? %>
       <button type="submit" name="build_now" class="build_button">Build Now</button>
     <% else %>
       <button type="submit" name="build_now" class="build_button" disabled="disabled">Build Now</button>
     <% end %>
-    
+
   <% end %>
-  
+
+  <% unless project.builder_down? %>
+    <%= form_tag(kill_build_project_path(:id => project), :class => "build_project") do %>
+      <button type="submit" name="build_now" class="kill_build_button">Kill Builder</button>
+    <% end %>
+  <% end %>
+
   <%= display_builder_state(project.builder_state_and_activity) %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ CruiseControl::Application.routes.draw do
   resources :projects, :constraints => { :id => /.*/ } do
     member do
       post :build, :constraints => { :id => /.*/ }
+      post :kill_build, :constraints => { :id => /.*/ }
       get :getting_started, :constraints => { :id => /.*/ }
     end
   end

--- a/lib/platform.rb
+++ b/lib/platform.rb
@@ -64,7 +64,7 @@ module Platform
 
           # safely exec
           Process.detach(pid)
-          pid_file = Rails.root.join('tmp', 'pids', 'builders', "#{project_name}.pid")
+          pid_file = project_pid_file(project_name)
           FileUtils.mkdir_p(File.dirname(pid_file))
           File.open(pid_file, "w") {|f| f.write pid }
         rescue NotImplementedError   # Kernel.fork exists but not implemented in Windows
@@ -76,6 +76,17 @@ module Platform
     end
   end
   module_function :create_child_process
+
+  def project_pid_file(project_name)
+    Rails.root.join('tmp', 'pids', 'builders', "#{project_name}.pid")
+  end
+  module_function :project_pid_file
+
+  def kill_child_process(project_name)
+    pid = File.read(project_pid_file(project_name)).chomp
+    Kernel.system("kill -9 #{pid}")
+  end
+  module_function :kill_child_process
 
   def safely_exec(command)
     if running_as_daemon?

--- a/lib/platform.rb
+++ b/lib/platform.rb
@@ -84,7 +84,8 @@ module Platform
 
   def kill_child_process(project_name)
     pid = File.read(project_pid_file(project_name)).chomp
-    Kernel.system("kill -9 #{pid}")
+    kill_tree = File.join(RAILS_ROOT, 'script', 'killtree')
+    Kernel.system("#{kill_tree} #{pid}")
   end
   module_function :kill_child_process
 

--- a/public/stylesheets/cruisecontrol.css
+++ b/public/stylesheets/cruisecontrol.css
@@ -406,3 +406,13 @@ form.new_project dd {
   float: left;
   width: 300px;
 }
+.kill_build_button{
+  background:#FF0000;
+  background:-moz-linear-gradient(top, #FF5757 0%, #FF0000 100%);
+  background:-webkit-gradient(linear, 0% 0%, 0% 100%, from(#FF5757), to(#FF0000));
+}
+.kill_build_button:hover {
+  background:#FF0000;
+  background:-moz-linear-gradient(top, #FF5757 0%, #FF0000 100%);
+  background:-webkit-gradient(linear, 0% 0%, 0% 100%, from(#FF5757), to(#FF0000));
+}

--- a/script/killtree
+++ b/script/killtree
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+def kill_tree(pid)
+  child_parent_processes = `ps -eo pid,ppid | grep #{pid}`
+  child_parent_processes = child_parent_processes.split("\n").map{|child_and_parent| child_and_parent.strip.gsub(/\s+/, " ").split(" ")}
+  child_parent_processes.each do |child, parent|
+    if parent == pid
+      kill_tree(child)
+    end
+  end
+  system "kill -9 #{pid}"
+end
+
+kill_tree(ARGV[0])

--- a/test/functional/projects_controller_test.rb
+++ b/test/functional/projects_controller_test.rb
@@ -220,9 +220,29 @@ class ProjectsControllerTest < ActionController::TestCase
       Configuration.stubs(:disable_build_now).returns(true)
 
       post :build, :id => 'one'
-      
+
       assert_response 403
       assert_equal 'Build requests are not allowed', @response.body
+    end
+  end
+
+  context "POST /projects/:id/kill_build" do
+    test "should kill the running builder" do
+      project = create_project_stub('two')
+      Project.expects(:find).with('two').returns(project)
+      project.expects(:kill_build)
+      post :kill_build, :id => "two"
+      assert_response :redirect
+    end
+  end
+
+  context "XHR POST /projects/:id/kill_build" do
+    test "should kill the running builder" do
+      project = create_project_stub('two')
+      Project.expects(:find).with('two').returns(project)
+      project.expects(:kill_build)
+      xhr :post, :kill_build, :id => "two"
+      assert_response :success
     end
   end
 

--- a/test/unit/project_test.rb
+++ b/test/unit/project_test.rb
@@ -373,6 +373,14 @@ class ProjectTest < ActiveSupport::TestCase
     end       
   end
 
+  def test_kill_build_should_kill_build
+    in_sandbox do |sandbox|
+      @project.path = sandbox.root
+      Platform.expects(:kill_child_process).with(@project.name)
+      @project.kill_build
+    end
+  end
+
   def test_request_build_should_generate_build_requested_file_and_notify_listeners
     @project.stubs(:builder_state_and_activity).returns('sleeping')
     in_sandbox do |sandbox|


### PR DESCRIPTION
This adds support for killing running builders, we use the kill_tree script to kill all child processes, we don't have support for windows, sorry.
