### PR TITLE
Sometimes we need to pass variables to the build command through environment, but because of Bundler.with_clean_env it is not possible now

### DIFF
--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -189,10 +189,17 @@ EOF
   
   def in_clean_environment_on_local_copy(&block)
     old_rails_env = ENV['RAILS_ENV']
+    old_environment = project.environment.keys.each_with_object({}) do |key, env|
+      env[key] = ENV[key]
+    end
 
     Bundler.with_clean_env do
       begin
         ENV['RAILS_ENV'] = nil
+
+        project.environment.each do |key, value|
+          ENV[key] = value
+        end
 
         # set OS variable CC_BUILD_ARTIFACTS so that custom build tasks know where to redirect their products
         ENV['CC_BUILD_ARTIFACTS'] = self.artifacts_directory
@@ -208,6 +215,10 @@ EOF
         end
       ensure
         ENV['RAILS_ENV'] = old_rails_env
+
+        old_environment.each do |key, value|
+          ENV[key] = value
+        end
       end
     end
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -527,7 +527,11 @@ class Project
   def gemfile
     File.join(self.local_checkout, @gemfile || "Gemfile")
   end
-  
+
+  def environment
+    @environment ||= {}
+  end
+
   private
   
   # sorts a array of builds in order of revision number and rebuild number 

--- a/test/unit/build_test.rb
+++ b/test/unit/build_test.rb
@@ -352,6 +352,24 @@ class BuildTest < ActiveSupport::TestCase
         ENV['RAILS_ENV'] = 'test'
       end
     end
+
+    test "should pass project environment variables to the block" do
+      begin
+        cc_db_prefix, ENV["CC_DB_PREFIX"] = ENV["CC_DB_PREFIX"], "test_"
+        with_sandbox_project do |sandbox, project|
+          project.environment["CC_DB_PREFIX"] = "master_"
+          build = Build.new(project, 1)
+
+          build.in_clean_environment_on_local_copy do
+            assert_equal "master_", ENV["CC_DB_PREFIX"]
+          end
+
+          assert_equal "test_", ENV["CC_DB_PREFIX"]
+        end
+      ensure
+        ENV["CC_DB_PREFIX"] = cc_db_prefix
+      end
+    end
   end  
 
   context "#abbreviated_label" do

--- a/test/unit/project_test.rb
+++ b/test/unit/project_test.rb
@@ -885,7 +885,19 @@ class ProjectTest < ActiveSupport::TestCase
       assert_equal File.join(@project.local_checkout, "little_treasures/HEY_GUYS_GEMFILE_IS_RIGHT_HERE"), @project.gemfile
     end
   end
-    
+
+  context "#environment" do
+    test "should return empty Hash when no environment variables specified" do
+      assert_equal({}, @project.environment)
+    end
+
+    test "should allow assiging environment variables" do
+      @project.environment["CC_DB_PREFIX"] = "master_"
+      @project.environment["CC_HBASE_ENABLED"] = "false"
+      assert_equal({ "CC_DB_PREFIX" => "master_", "CC_HBASE_ENABLED" => "false" }, @project.environment)
+    end
+  end
+
   private
   
     def stub_build(label)


### PR DESCRIPTION
Added ability to set custom environment variables in cruise_config.rb via project.environment hash
