### PR TITLE
BUNDLE_GEMFILE environment variable is passed to the build command

### DIFF
--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -193,10 +193,12 @@ EOF
   
   def in_clean_environment_on_local_copy(&block)
     old_rails_env = ENV['RAILS_ENV']
+    old_bundle_gemfile = ENV['BUNDLE_GEMFILE']
 
     Bundler.with_clean_env do
       begin
         ENV['RAILS_ENV'] = nil
+        ENV['BUNDLE_GEMFILE'] = nil
 
         # set OS variable CC_BUILD_ARTIFACTS so that custom build tasks know where to redirect their products
         ENV['CC_BUILD_ARTIFACTS'] = self.artifacts_directory
@@ -212,6 +214,7 @@ EOF
         end
       ensure
         ENV['RAILS_ENV'] = old_rails_env
+        ENV['BUNDLE_GEMFILE'] = old_bundle_gemfile
       end
     end
   end

--- a/test/unit/build_test.rb
+++ b/test/unit/build_test.rb
@@ -384,6 +384,23 @@ class BuildTest < ActiveSupport::TestCase
         ENV['RAILS_ENV'] = 'test'
       end
     end
+
+    test "should not pass BUNDLE_GEMFILE to the block" do
+      begin
+        bundle_gemfile, ENV["BUNDLE_GEMFILE"] = ENV["BUNDLE_GEMFILE"], "GemfileOld"
+        with_sandbox_project do |sandbox, project|
+          build = Build.new(project, 1)
+
+          build.in_clean_environment_on_local_copy do
+            assert_equal nil, ENV["BUNDLE_GEMFILE"]
+          end
+
+          assert_equal "GemfileOld", ENV["BUNDLE_GEMFILE"]
+        end
+      ensure
+        ENV["BUNDLE_GEMFILE"] = bundle_gemfile
+      end
+    end
   end  
 
   context "#abbreviated_label" do


### PR DESCRIPTION
The same thing as with RAILS_ENV variable — we should clear it before executing build command, or project specific Gemfile will not work
