### PR TITLE
Default branch is not always "master"

### DIFF
--- a/lib/source_control/git.rb
+++ b/lib/source_control/git.rb
@@ -24,7 +24,7 @@ module SourceControl
       # need to read from command output, because otherwise tests break
       git('clone', [@repository, path], :execute_in_project_directory => false)
 
-      if @branch and @branch != 'master'
+      if @branch and @branch != current_branch
         git('branch', ['--track', @branch, "origin/#{@branch}"])
         git('checkout', ['-q', @branch]) # git prints 'Switched to branch "branch"' to stderr unless you pass -q 
       end

--- a/test/unit/source_control/git_test.rb
+++ b/test/unit/source_control/git_test.rb
@@ -72,6 +72,7 @@ class SourceControl::GitTest < ActiveSupport::TestCase
     in_sandbox do
       git = new_git(:repository => "git:/my_repo", :branch => "mybranch")
       git.expects(:git).with("clone", ["git:/my_repo", '.'], :execute_in_project_directory => false)
+      git.stubs(:current_branch).returns('master')
       git.expects(:git).with("branch", ["--track", 'mybranch', 'origin/mybranch'])
       git.expects(:git).with("checkout", ["-q", 'mybranch'])
       git.checkout
@@ -82,6 +83,27 @@ class SourceControl::GitTest < ActiveSupport::TestCase
     in_sandbox do
       git = new_git(:repository => "git:/my_repo", :branch => "master")
       git.expects(:git).with("clone", ["git:/my_repo", '.'], :execute_in_project_directory => false)
+      git.stubs(:current_branch).returns('master')
+      git.checkout
+    end
+  end
+
+  def test_checkout_with_master_branch_explicitly_specified_when_master_is_not_default_should_perform_git_branch_and_checkout
+    in_sandbox do
+      git = new_git(:repository => "git:/my_repo", :branch => "master")
+      git.expects(:git).with("clone", ["git:/my_repo", '.'], :execute_in_project_directory => false)
+      git.stubs(:current_branch).returns('mybranch')
+      git.expects(:git).with("branch", ["--track", 'master', 'origin/master'])
+      git.expects(:git).with("checkout", ["-q", 'master'])
+      git.checkout
+    end
+  end
+
+  def test_checkout_with_default_branch_explicitly_specified_should_not_perform_git_branch_and_checkout
+    in_sandbox do
+      git = new_git(:repository => "git:/my_repo", :branch => "mybranch")
+      git.expects(:git).with("clone", ["git:/my_repo", '.'], :execute_in_project_directory => false)
+      git.stubs(:current_branch).returns('mybranch')
       git.checkout
     end
   end


### PR DESCRIPTION
Don't try to switch branch when default branch is not _master_ and the build branch is the default branch.

`git branch --track development origin/development` fails if you're already on the _development_ branch. 
