### PR TITLE
make build in progress honor the 'dashboard_refresh_interval' config. issue #61

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,7 @@
   
 
   <% if @autorefresh %>
-    <meta http-equiv="refresh" content="5">
+    <meta http-equiv="refresh" content="<%= Configuration.dashboard_refresh_interval.to_i * 1000 %>">
     <meta http-equiv="cache-control" content="no-cache">
   <% end %>
   <% if @rss_feeds -%>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,7 @@
   
 
   <% if @autorefresh %>
-    <meta http-equiv="refresh" content="<%= Configuration.dashboard_refresh_interval.to_i * 1000 %>">
+    <meta http-equiv="refresh" content="<%= Configuration.dashboard_refresh_interval.to_i %>">
     <meta http-equiv="cache-control" content="no-cache">
   <% end %>
   <% if @rss_feeds -%>


### PR DESCRIPTION
Our log files are kinda large and we can have many people looking at the build so in site_config.rb I set:

Configuration.dashboard_refresh_interval = 90.seconds

When I'm looking at the build in progress it will still auto-refresh every 5 seconds. I realize the distinction between project & build but with the auto-refresh I can't scroll down to view logs or check out current failures without the page resetting. 

This is a proposed patch to honor Configuration.dashboard_refresh_interval for in-progress build pages.
