### PR TITLE
Simplify locating the artifacts for the most recent successful build of a project

### DIFF
--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -44,7 +44,19 @@ class BuildsController < ApplicationController
       render_not_found
     end
   end
-  
+
+  def latest_successful
+    render :text => 'Project not specified', :status => 404 and return unless params[:project]
+
+    @project = Project.find(params[:project])
+    render :text => "Project #{params[:project].inspect} not found", :status => 404 and return unless @project
+    @build = @project.builds.find_all(&:successful?).last
+    render :text => "No successful build found", :status => 404 and return unless @build
+
+    redirect_to build_path(@project, @build) +
+                (params[:path] ? "/#{params[:path]}" : "")
+  end
+
   private
 
     MIME_TYPES = {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,8 @@ CruiseControl::Application.routes.draw do
   end
 
   match 'builds/older/:project' => 'builds#drop_down', :as => :builds_drop_down, :project => /[^\/]+/
+
+  match 'builds/:project/latest_successful(/*path)' => 'builds#latest_successful', :as => :latest_successful_build, :project => /[^\/]+/
   match 'builds/:project/:build/artifacts/*path' => 'builds#artifact', :as => :build_artifact, :build => /[^\/]+/, :project => /[^\/]+/
   match 'builds/:project/:build' => 'builds#show', :as => :build, :build => /[^\/]+/, :project => /[^\/]+/
   match 'builds/:project' => 'builds#show', :as => :project_without_builds, :project => /[^\/]+/

--- a/test/functional/builds_controller_test.rb
+++ b/test/functional/builds_controller_test.rb
@@ -52,6 +52,90 @@ class BuildsControllerTest < ActionController::TestCase
     end
   end
 
+  context "GET /builds/:project/latest_successful" do
+    test "should redirect to the latest successful build" do
+      with_sandbox_project do |sandbox, project|
+        create_builds 1, 2
+
+        Project.expects(:find).with(project.name).times(2).returns(project)
+
+        get :latest_successful, :project => project.name
+
+        assert_response :redirect
+        assert_redirected_to build_path(assigns(:project), :build => 2)
+
+
+        create_build 3, :failed
+
+        get :latest_successful, :project => project.name
+
+        assert_response :redirect
+        assert_redirected_to build_path(assigns(:project), :build => 2)
+      end
+    end
+
+    test "should render a 404 and an error page if there are no successful builds" do
+      with_sandbox_project do |sandbox, project|
+        Project.expects(:find).with(project.name).times(2).returns(project)
+
+        get :latest_successful, :project => project.name
+
+        assert_response 404
+        assert_equal 'No successful build found', @response.body
+
+
+        create_build 1, :failed
+
+        get :latest_successful, :project => project.name
+
+        assert_response 404
+        assert_equal 'No successful build found', @response.body
+      end
+    end
+  end
+
+  context "GET /builds/:project/latest_successful/*path" do
+    test "should redirect to the latest successful build with the same path" do
+      with_sandbox_project do |sandbox, project|
+        create_builds 1, 2
+
+        Project.expects(:find).with(project.name).times(2).returns(project)
+
+        get :latest_successful, :project => project.name, :path => "the/path"
+
+        assert_response :redirect
+        assert_redirected_to build_path(assigns(:project), :build => 2) + "/the/path"
+
+
+        create_build 3, :failed
+
+        get :latest_successful, :project => project.name, :path => "the/path"
+
+        assert_response :redirect
+        assert_redirected_to build_path(assigns(:project), :build => 2) + "/the/path"
+      end
+    end
+
+    test "should render a 404 and an error page if there are no successful builds" do
+      with_sandbox_project do |sandbox, project|
+        Project.expects(:find).with(project.name).times(2).returns(project)
+
+        get :latest_successful, :project => project.name, :path => "the/path"
+
+        assert_response 404
+        assert_equal 'No successful build found', @response.body
+
+
+        create_build 1, :failed
+
+        get :latest_successful, :project => project.name, :path => "the/path"
+
+        assert_response 404
+        assert_equal 'No successful build found', @response.body
+      end
+    end
+  end
+
   context "GET /builds/:project/:id" do
     test "should render the show template with the requested project and build" do
       with_sandbox_project do |sandbox, project|

--- a/test/lib/build_factory.rb
+++ b/test/lib/build_factory.rb
@@ -10,7 +10,7 @@ module BuildFactory
   end
 
   def create_build(label, status = :success)
-    @sandbox.new :file => "build-#{label}/build_status.#{status}"
+    @sandbox.new :directory => "build-#{label}-#{status}"
   end
   
   def create_builds(*labels)

--- a/test/unit/plugins/build_reaper_test.rb
+++ b/test/unit/plugins/build_reaper_test.rb
@@ -26,7 +26,7 @@ class BuildReaperTest < Test::Unit::TestCase
     
     @reaper.delete_all_builds_but 4
     
-    assert_equal %w(build-6 build-7 build-8 build-9), Dir["*"].sort
+    assert_equal %w(build-6-success build-7-success build-8-success build-9-success), Dir["*"].sort
   end
   
   def test_should_delete_no_builds
@@ -34,6 +34,6 @@ class BuildReaperTest < Test::Unit::TestCase
     
     @reaper.delete_all_builds_but 2
     
-    assert_equal %w(build-1), Dir["*"]
+    assert_equal %w(build-1-success), Dir["*"]
   end
 end


### PR DESCRIPTION
Merging these changes will add a faux build ID named `latest_successful` for projects that when used will trigger a redirect to the build ID for the given project that was most recently completed successfully.  This redirection works for any sub-paths of the build, including artifacts.  404 results are returned for invalid projects and projects without any successful builds.

This makes it easy to share a static link with others that will always point them to the latest build for a project so that they can make use of any relevant artifacts.
