### PR TITLE
Fixes #58 - Builder now uses data_root in the default log file path

### DIFF
--- a/config/environments/builder.rb
+++ b/config/environments/builder.rb
@@ -1,3 +1,4 @@
+CRUISE_OPTIONS = { :verbose => false }
 CruiseControl::Application.configure do
   config.cache_classes = true
   config.paths.log = CRUISE_OPTIONS[:log_file_name] || 'log/builder_WITHOUT_A_NAME.log'

--- a/script/builder
+++ b/script/builder
@@ -3,9 +3,8 @@
 ENV["RAILS_ENV"] = 'builder'
 
 require File.expand_path(File.dirname(__FILE__) + '/../config/boot')
+require File.expand_path(File.dirname(__FILE__) + "/../config/environment")
 require 'optparse'
-
-CRUISE_OPTIONS = { :verbose => false }
 
 ARGV.options do |opts|
   opts.banner = "Usage: cruise builder <project_name> [options]"
@@ -26,10 +25,10 @@ ARGV.options do |opts|
   end
 
   CRUISE_OPTIONS[:project_name] = args[0]
-  CRUISE_OPTIONS[:log_file_name] = "log/#{CRUISE_OPTIONS[:project_name]}_builder.log"
+  CRUISE_OPTIONS[:log_file_name] = "#{Configuration.data_root}/#{CRUISE_OPTIONS[:project_name]}_builder.log"
 end
 
-require File.expand_path(File.dirname(__FILE__) + "/../config/environment")
+
 
 CruiseControl::Log.verbose = CRUISE_OPTIONS[:verbose]
 


### PR DESCRIPTION
Fixes #58 - Builder now uses data_root (.cruise) in the default log file path.
