### PR TITLE
Fixes #58 - Builder now logs to data_root, also migrates old log files

### DIFF
--- a/config/environments/builder.rb
+++ b/config/environments/builder.rb
@@ -1,6 +1,8 @@
 CruiseControl::Application.configure do
+  CRUISE_OPTIONS[:log_file_name] = 
+    "#{CruiseControl.data_root}/#{CRUISE_OPTIONS[:project_name] || "NOT_NAMED"}_builder.log"
   config.cache_classes = true
-  config.paths.log = CRUISE_OPTIONS[:log_file_name] || 'log/builder_WITHOUT_A_NAME.log'
+  config.paths.log = CRUISE_OPTIONS[:log_file_name]
   config.log_level = CRUISE_OPTIONS[:verbose] ? :debug : :info
   config.active_support.deprecation = :notify
 

--- a/lib/builder_plugins/project_logger.rb
+++ b/lib/builder_plugins/project_logger.rb
@@ -1,5 +1,5 @@
 #
-# this plugin logs build events to a project log file in logs/<project name>_builder.log
+# this plugin logs build events to a project log file in $CRUISE/<project name>_builder.log
 #
 # (this plugin is built in and needs no customization)
 #

--- a/script/builder
+++ b/script/builder
@@ -4,6 +4,7 @@ ENV["RAILS_ENV"] = 'builder'
 
 require File.expand_path(File.dirname(__FILE__) + '/../config/boot')
 require 'optparse'
+require 'fileutils'
 
 CRUISE_OPTIONS = { :verbose => false }
 
@@ -26,7 +27,6 @@ ARGV.options do |opts|
   end
 
   CRUISE_OPTIONS[:project_name] = args[0]
-  CRUISE_OPTIONS[:log_file_name] = "log/#{CRUISE_OPTIONS[:project_name]}_builder.log"
 end
 
 require File.expand_path(File.dirname(__FILE__) + "/../config/environment")
@@ -72,9 +72,22 @@ def load_project(path)
   end
 end
 
+def migrate_old_logs
+  old_log = File.expand_path("log/#{CRUISE_OPTIONS[:project_name]}_builder.log")
+  if File.exists? old_log
+    new_log = File.expand_path(CRUISE_OPTIONS[:log_file_name])
+    if File.exists? new_log
+      FileUtils.mv(old_log, "#{new_log}.old")
+    else
+      FileUtils.mv(old_log, new_log)
+    end
+  end
+end
+
 project = nil
 
 begin
+  migrate_old_logs
   project = load_project(project_path)
   startup(project)
 


### PR DESCRIPTION
Builder now logs to data_root (i.e. .cruise/[project_name]_builder.log).  Also attempts to migrate any old logs from /log should they exist.

Sorry for the double pull request, please ignore the original (https://github.com/thoughtworks/cruisecontrol.rb/pull/77).
