### PR TITLE
Fixes RSS - Removed id constraint from project resource route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 CruiseControl::Application.routes.draw do
   match '/' => 'projects#index', :as => :root
   
-  resources :projects, :constraints => { :id => /.*/ } do
+  resources :projects  do
     member do
       post :build, :constraints => { :id => /.*/ }
       post :kill_build, :constraints => { :id => /.*/ }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 CruiseControl::Application.routes.draw do
   match '/' => 'projects#index', :as => :root
   
-  resources :projects  do
+  resources :projects do
     member do
       post :build, :constraints => { :id => /.*/ }
       post :kill_build, :constraints => { :id => /.*/ }


### PR DESCRIPTION
RSS feed (from projects screen) was not useable as the id constraint on the project resource route was causing the format to be passed as part of the id.
