### PR TITLE
allow broken symlinks in build artifacts

### DIFF
--- a/app/views/builds/show_dir_index.html.erb
+++ b/app/views/builds/show_dir_index.html.erb
@@ -10,7 +10,7 @@
   <tr>
     <td><%= link_to f, f %></td>
     <td><%= file_mtime(f) %></td>
-    <td><%= file_size(f) %> bytes</td>
+    <td><%= file_size(f) rescue 0 %> bytes</td>
     <td><%= file_type(f) %></td>
   </tr>
   <% end %>


### PR DESCRIPTION
currently, a broken symlink in a build artifact will prevent directory indices from being shown.  This fixes that.  I think.
