### PR TITLE
Fix for Issue #78: Project creation UI workflow requires validation

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -23,6 +23,8 @@ class ProjectsController < ApplicationController
     project = Project.create(params[:project][:name], scm)
 
     redirect_to getting_started_project_path(project.id)
+  rescue ArgumentError => e
+    redirect_to new_project_path, :flash => {:notice => e.message}
   end
 
   def getting_started

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -17,6 +17,7 @@ class Project
     end
     
     def create(project_name, scm, dir=Configuration.projects_root)
+      raise ArgumentError, "Project Name is required" if project_name.blank?
       Project.new(:name => project_name, :scm => scm).tap do |project|
         raise "Project named #{project.name.inspect} already exists in #{dir}" if Project.all(dir).include?(project)
         begin

--- a/lib/source_control.rb
+++ b/lib/source_control.rb
@@ -5,7 +5,7 @@ module SourceControl
   class << self
 
     def create(scm_options)
-      raise ArgumentError, "options should include repository" unless scm_options[:repository]
+      raise ArgumentError, "Repository path is required" if scm_options[:repository].blank?
       scm_type = scm_options[:source_control]
 
       source_control_class = if scm_type.nil?

--- a/test/functional/projects_controller_test.rb
+++ b/test/functional/projects_controller_test.rb
@@ -326,6 +326,22 @@ class ProjectsControllerTest < ActionController::TestCase
         assert_redirected_to getting_started_project_path("new_project")
       end
     end
+
+    test "should display an error if Project Name is blank" do
+      in_sandbox do
+        source_control = { :repository => 'path', :source_control => 'fake_source_control' }
+        post :create, :project => { :project_name => "", :source_control => source_control}
+        assert_match /Project Name/, flash[:notice]
+        assert_redirected_to new_project_path
+      end
+    end
+    test "should display an error if Repostory path is blank" do
+      in_sandbox do
+        post :create, :project => {:project_name => 'My Cool Project', :source_control => {}}
+        assert_match /Repository/, flash[:notice]
+        assert_redirected_to new_project_path
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Simple fix to detect when we try and create a Project or a SourceControl instance with blank parameters and bubble the error up to the flash notice.

Thanks

Matt
