### PR TITLE
move project_status div over slightly so it doesn't overlap with change build info

### DIFF
--- a/public/stylesheets/cruisecontrol.less
+++ b/public/stylesheets/cruisecontrol.less
@@ -227,7 +227,7 @@ a:hover {
 
     .project_status  { 
       bottom: 2px;
-      left: 240px;
+      left: 280px;
     }
 
     .upper {


### PR DESCRIPTION
The changeset build info will overlap with build status on occasion with the right conditions that make the string longer.  This happened on Google Chrome on OS X with no font-resizing.  See below:

![Alt text](http://i.imgur.com/quAaR.png)
