### PR TITLE
Fixes exception when log is empty

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -76,7 +76,7 @@ module ApplicationHelper
   end
 
   def format_changeset_log(log)
-    h(log.strip)
+    h(log.strip) if log.present?
   end
   
   def elapsed_time(build, format = :general)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -76,7 +76,8 @@ module ApplicationHelper
   end
 
   def format_changeset_log(log)
-    h(log.strip) if log.present?
+    log = "" if log.blank?
+    h(log.strip)
   end
   
   def elapsed_time(build, format = :general)

--- a/test/unit/application_helper_test.rb
+++ b/test/unit/application_helper_test.rb
@@ -35,6 +35,11 @@ class ApplicationHelperTest < ActionView::TestCase
   end
 
   context "#format_changeset_log" do
+    test "should render nothing if log is nil" do
+      @helper.extend(ERB::Util)
+      assert_equal "", @helper.format_changeset_log(nil)
+    end
+
     test "should strip html tags" do
       @helper.extend(ERB::Util)
       assert_equal "&lt;hr /&gt;some changeset&lt;script&gt;alert('bad')&lt;/script&gt;",


### PR DESCRIPTION
This fixes an exception I would receive if there was no log yet, which usually happens if the project is not built yet.

Also added a test.
