### PR TITLE
Correctly update repo to latest or requested version when cleaning git working dir

### DIFF
--- a/lib/source_control/git.rb
+++ b/lib/source_control/git.rb
@@ -36,6 +36,7 @@ module SourceControl
       # (-d) Directory clean
       # (-q) Quiet, prevent git from writing unnecessary information to stdout/stderr 
       git('clean', ['-q', '-d', '-f'])
+      update(revision || latest_revision)
     end
 
     def latest_revision

--- a/test/integration/git_integration_test.rb
+++ b/test/integration/git_integration_test.rb
@@ -17,6 +17,8 @@ class GitIntegrationTest < ActiveSupport::TestCase
       FileUtils.touch tracked_file
       sandbox_git_add_and_commit(proj_dir, File.basename(tracked_file))
       untracked_file = File.join(proj_dir, 'untracked.txt')
+      git.expects(:latest_revision).returns(:foo)
+      git.expects(:update).with(:foo)
       git.clean_checkout
       assert File.exist? tracked_file
       assert_false File.exist? untracked_file
@@ -27,6 +29,8 @@ class GitIntegrationTest < ActiveSupport::TestCase
     with_sandboxed_git do |proj_dir, git|
       untracked_dirs = File.join(proj_dir, 'untracked/by/git')
       FileUtils.mkdir_p untracked_dirs
+      git.expects(:latest_revision).returns(:foo)
+      git.expects(:update).with(:foo)
       git.clean_checkout
       assert_false File.directory? untracked_dirs
     end
@@ -36,6 +40,8 @@ class GitIntegrationTest < ActiveSupport::TestCase
     with_sandboxed_git do |proj_dir, git|
       untracked_file = File.join(proj_dir, 'untracked.txt')
       FileUtils.touch untracked_file
+      git.expects(:latest_revision).returns(:foo)
+      git.expects(:update).with(:foo)
       git.clean_checkout
       assert_false File.exist? untracked_file
     end

--- a/test/unit/source_control/git_test.rb
+++ b/test/unit/source_control/git_test.rb
@@ -130,6 +130,8 @@ class SourceControl::GitTest < ActiveSupport::TestCase
     in_sandbox do
       git = new_git(:repository => "git:/my_repo")
       git.expects(:git).with("clean", ['-q', '-d', '-f'])
+      git.expects(:latest_revision).returns(:foo)
+      git.expects(:update).with(:foo)
       git.clean_checkout
     end
   end


### PR DESCRIPTION
If you do not explicitly update the working dir after git clean it will stay at the old revision, leading to continuous builds of the same outdated revision.
