### PR TITLE
Sort files in sub artifacts directories

### DIFF
--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -135,7 +135,7 @@ EOF
   end
 
   def files_in(path)
-    Dir["#{artifacts_directory}/#{path}/*"].collect {|f| f.gsub("#{artifacts_directory}/", '') }
+    Dir["#{artifacts_directory}/#{path}/*"].sort.collect {|f| f.gsub("#{artifacts_directory}/", '') }
   end
   
   def artifacts_directory

--- a/cruisecontrolrb.gemspec
+++ b/cruisecontrolrb.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
     [ "rake", "0.8.7" ],
     [ "jquery-rails", '1.0.9' ],
     [ "abstract", "1.0.0" ],
+    [ "mongrel", "1.1.5" ],
   ].each do |gem, version|
     s.add_dependency gem, version
   end

--- a/daemon/daemon_helper.rb
+++ b/daemon/daemon_helper.rb
@@ -56,7 +56,7 @@ def restart(start_cmd)
 end
 
 def start(start_cmd)
-  cmd = start_cmd || "cd #{CRUISE_HOME} && ./cruise start -d"
+  cmd = start_cmd || "cd #{CRUISE_HOME} && nohup ./cruise start -d  > /dev/null 2>&1"
   log(:env, ENV.inspect)
 
   # remove cruise pid file if process is no longer running


### PR DESCRIPTION
We make excessive use of the build artifacts directory, e.g. by providing lots of screen shoots from some frontend test. The current file listing looks randomly to me or FIFO. I added a very little patch the the listing is now sorted alphabetically (similar to ls -l). Maybe it's useful generally.
