### PR TITLE
Append a / to directory names when listing files in the artifacts directory

### DIFF
--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -83,7 +83,9 @@ EOF
   alias abort destroy
 
   def additional_artifacts
-    Dir.entries(artifacts_directory).find_all {|artifact| !(artifact =~ IGNORE_ARTIFACTS) }
+    Dir.entries(artifacts_directory).find_all {|artifact| !(artifact =~ IGNORE_ARTIFACTS) }.map do |file_name|
+      File.ftype("#{artifacts_directory}/#{file_name}") == 'directory' ? file_name + '/' : file_name
+    end
   end
   
   def status

--- a/test/unit/build_test.rb
+++ b/test/unit/build_test.rb
@@ -360,7 +360,7 @@ class BuildTest < ActiveSupport::TestCase
 
         build = Build.new(project, 1)
         assert_equal(%w(coverage foo foo.txt), build.additional_artifacts.sort)
-        assert_equal ["coverage/functionals", "coverage/index.html", "coverage/units"], build.files_in('coverage')
+        assert_equal ["coverage/functionals/", "coverage/index.html", "coverage/units/"], build.files_in('coverage')
       end
     end
   end


### PR DESCRIPTION
This makes it easier to visually pick out directories when viewing the artifacts.
