### PR TITLE
Remove untracked files including build products

### DIFF
--- a/lib/source_control/git.rb
+++ b/lib/source_control/git.rb
@@ -32,10 +32,11 @@ module SourceControl
     end
 
     def clean_checkout(revision = nil, stdout = $stdout)
-      # (-f) Forcing the clean incase git clean.requireForce is set to true
+      # (-f) Forcing the clean in case git clean.requireForce is set to true
+      # (-x) Remove untracked files including build products
       # (-d) Directory clean
       # (-q) Quiet, prevent git from writing unnecessary information to stdout/stderr 
-      git('clean', ['-q', '-d', '-f'])
+      git('clean', ['-q', '-d', '-x', '-f'])
     end
 
     def latest_revision


### PR DESCRIPTION
In my company we use -x to let clean checkouts be as close as possible to clones without incurring the overhead of a clone. The difference with the current setting is that untracked files (build products) will also be removed. I think that's appropriate. The git-clean man page says this about -x: "This can be used (possibly in conjunction with git reset) to create a pristine working directory to test a clean build.". Please contact me if you have any questions. Thanks!
